### PR TITLE
Fix to #4

### DIFF
--- a/KVLib/KVParser.cs
+++ b/KVLib/KVParser.cs
@@ -22,8 +22,8 @@ namespace KVLib
             select first;
 
             
-        static Parser<string> KVString =            
-            from rest in Parse.AnyChar.Except(DisallowedKeyChar).Until(Parse.WhiteSpace.AtLeastOnce().Or(Parse.Regex("\"//.[\\w ]*")))
+        static Parser<string> KVString =
+            from rest in Parse.AnyChar.Except(DisallowedKeyChar).Until(Parse.WhiteSpace.AtLeastOnce().Or(Parse.Regex("\"//.*")))
             select new string(rest.ToArray());
 
 


### PR DESCRIPTION
Checks with regex for variations on: ["// a comment] ["//a comment] etc
It worked on most my test cases, its possible theres still some cases where it parses it wrongly
